### PR TITLE
added a missing 's' to 'parserOption'

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = {
         'mocha': true,
         'mongo': true
     },
-    'parserOption': {
+    'parserOptions': {
         'ecmaVersion': 6,
         'ecmaFeatures': {
             'globalReturn': true


### PR DESCRIPTION
There was a typo that was making the linter not work. Relevant documentation can be found here: http://eslint.org/docs/user-guide/configuring